### PR TITLE
Style flicker fix

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,30 @@
+import Document from "next/document";
+import { ServerStyleSheet } from "styled-components";
+
+export default class MyDocument extends Document {
+	static async getInitialProps(ctx) {
+		const sheet = new ServerStyleSheet();
+		const originalRenderPage = ctx.renderPage;
+
+		try {
+			ctx.renderPage = () =>
+				originalRenderPage({
+					enhanceApp: (App) => (props) =>
+						sheet.collectStyles(<App {...props} />),
+				});
+
+			const initialProps = await Document.getInitialProps(ctx);
+			return {
+				...initialProps,
+				styles: (
+					<>
+						{initialProps.styles}
+						{sheet.getStyleElement()}
+					</>
+				),
+			};
+		} finally {
+			sheet.seal();
+		}
+	}
+}


### PR DESCRIPTION
Sometimes the CSS doesn't load right away.

Suggested fix:
https://dev.to/rsanchezp/next-js-and-styled-components-style-loading-issue-3i68
https://github.com/vercel/next.js/blob/deprecated-main/examples/with-styled-components/pages/_document.js